### PR TITLE
Allows user to have custom api path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
   },
   "rutorrent": {
     "download_folder": "/mnt/local/downloads/torrents/rutorrent/completed",
-    "url": "https://user:pass@rutorrent.domain.com",
+    "url": "https://user:pass@rutorrent.domain.com/rutorrent/plugins/httprpc/action.php",
     "path_mappings": {
       "/mnt/local/downloads/torrents/": [
         "/downloads/torrents/"
@@ -115,7 +115,7 @@
 ```json
 "rutorrent": {
   "download_folder": "/mnt/local/downloads/torrents/rutorrent/completed",
-  "url": "https://user:pass@rutorrent.domain.com",
+  "url": "https://user:pass@rutorrent.domain.com/plugins/httprpc/action.php",
   "path_mappings": {
     "/mnt/local/downloads/torrents/": [
       "/downloads/torrents/"
@@ -130,7 +130,7 @@
 
 `url` - Your ruTorrent URL.
 
-  - This can be in the form of `https://user:pass@ipaddress`
+  - This can be in the form of `https://user:pass@ipaddress/plugins/httprpc/action.php`
 
 
 ### path mappings

--- a/utils/rtorrent.py
+++ b/utils/rtorrent.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class Rtorrent:
     def __init__(self, url):
-        self.url = "%s/RPC2" % url
+        self.url = url
         self.xmlrpc = ServerProxy(self.url)
 
     def get_torrents(self):


### PR DESCRIPTION
This can be different for every setup but my api path is "/plugins/httprpc/action.php" and this script wouldnt work because "/RPC2" would always be appended to the end of the url. The script is working great now!